### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol server for interacting with Ethereum wallets and networks using Ethers.js v6. This server provides LLMs with a standardized interface to interact with Ethereum networks, smart contracts, and wallets.
 
+<a href="https://glama.ai/mcp/servers/j75jbdup5m">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/j75jbdup5m/badge" alt="Ethers Wallet MCP server" />
+</a>
+
 ## Overview
 
 The MCP Ethers Wallet server implements the [Model Context Protocol](https://modelcontextprotocol.io) specification, providing LLMs with tools to:
@@ -153,4 +157,4 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## Author
 
-Dennison Bertram (dennison@tally.xyz) 
+Dennison Bertram (dennison@tally.xyz)


### PR DESCRIPTION
This PR adds a badge for the [MCP Ethers Wallet](https://glama.ai/mcp/servers/j75jbdup5m) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/j75jbdup5m">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/j75jbdup5m/badge" alt="Ethers Wallet MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.